### PR TITLE
use the b3sum --no-names flag instead of cut

### DIFF
--- a/with-b3
+++ b/with-b3
@@ -32,8 +32,7 @@ if [ -z "$separator" ]; then
   separator="-"
 fi
 
-sum=$(b3sum "$file_path")
-sum=$(echo "$sum" | cut -d ' ' -f 1)
+sum=$(b3sum --no-names "$file_path")
 
 echo "${file_path}${separator}b3-${sum}"
 


### PR DESCRIPTION
The `--no-names` flag is intended for this sort of use case, and hopefully it'll simplify things slightly. You could also consider using it in a one-liner like:

```bash
echo "README.md-b3-$(b3sum --no-names README.md)"
```